### PR TITLE
Add NSE Sectoral Heatmap and fix NaN JSON/Pandas issues

### DIFF
--- a/app.py
+++ b/app.py
@@ -102,7 +102,7 @@ def generate_heatmap_data(df):
     df_clean[numeric_cols] = df_clean[numeric_cols].fillna(0)
 
     # Other object columns
-    object_cols = df_clean.select_dtypes(include=['object']).columns
+    object_cols = df_clean.select_dtypes(include=['object', 'string']).columns
     df_clean[object_cols] = df_clean[object_cols].fillna('N/A')
 
     for _, row in df_clean.iterrows():
@@ -295,7 +295,7 @@ def load_recent_fired_events_from_db():
         # Handle NaNs for consistency
         numeric_cols = df.select_dtypes(include=[np.number]).columns
         df[numeric_cols] = df[numeric_cols].fillna(0)
-        object_cols = df.select_dtypes(include=['object']).columns
+        object_cols = df.select_dtypes(include=['object', 'string']).columns
         df[object_cols] = df[object_cols].fillna('N/A')
     return df
 
@@ -313,7 +313,7 @@ def load_all_day_fired_events_from_db():
     # Handle NaNs for JSON serialization
     numeric_cols = df.select_dtypes(include=[np.number]).columns
     df[numeric_cols] = df[numeric_cols].fillna(0)
-    object_cols = df.select_dtypes(include=['object']).columns
+    object_cols = df.select_dtypes(include=['object', 'string']).columns
     df[object_cols] = df[object_cols].fillna('N/A')
 
     # Convert timestamp to ISO format string for JSON serialization

--- a/app.py
+++ b/app.py
@@ -101,8 +101,8 @@ def generate_heatmap_data(df):
     numeric_cols = df_clean.select_dtypes(include=[np.number]).columns
     df_clean[numeric_cols] = df_clean[numeric_cols].fillna(0)
 
-    # Other object columns
-    object_cols = df_clean.select_dtypes(include=['object', 'string']).columns
+    # Other non-numeric columns
+    object_cols = df_clean.columns.difference(numeric_cols)
     df_clean[object_cols] = df_clean[object_cols].fillna('N/A')
 
     for _, row in df_clean.iterrows():
@@ -295,7 +295,7 @@ def load_recent_fired_events_from_db():
         # Handle NaNs for consistency
         numeric_cols = df.select_dtypes(include=[np.number]).columns
         df[numeric_cols] = df[numeric_cols].fillna(0)
-        object_cols = df.select_dtypes(include=['object', 'string']).columns
+        object_cols = df.columns.difference(numeric_cols)
         df[object_cols] = df[object_cols].fillna('N/A')
     return df
 
@@ -313,7 +313,7 @@ def load_all_day_fired_events_from_db():
     # Handle NaNs for JSON serialization
     numeric_cols = df.select_dtypes(include=[np.number]).columns
     df[numeric_cols] = df[numeric_cols].fillna(0)
-    object_cols = df.select_dtypes(include=['object', 'string']).columns
+    object_cols = df.columns.difference(numeric_cols)
     df[object_cols] = df[object_cols].fillna('N/A')
 
     # Convert timestamp to ISO format string for JSON serialization

--- a/app_output.log
+++ b/app_output.log
@@ -49,3 +49,45 @@ Skipping scan because cookies are not loaded.
  * Restarting with stat
  * Debugger is active!
  * Debugger PIN: 631-326-424
+ * Detected change in '/app/app.py', reloading
+Warning: Could not load TradingView cookies. Scanning will be disabled. Error: can't find cookies file
+
+Location:
+    rookie-rs/src/common/paths.rs:48:7
+Auto-scanning...
+Skipping scan because cookies are not loaded.
+Auto-scanning...
+Skipping scan because cookies are not loaded.
+Auto-scanning...
+Skipping scan because cookies are not loaded.
+Auto-scanning...
+Skipping scan because cookies are not loaded.
+Auto-scanning...
+Skipping scan because cookies are not loaded.
+Auto-scanning...
+Skipping scan because cookies are not loaded.
+ * Restarting with stat
+ * Debugger is active!
+ * Debugger PIN: 631-326-424
+ * Detected change in '/app/app.py', reloading
+Warning: Could not load TradingView cookies. Scanning will be disabled. Error: can't find cookies file
+
+Location:
+    rookie-rs/src/common/paths.rs:48:7
+Auto-scanning...
+Skipping scan because cookies are not loaded.
+Auto-scanning...
+Skipping scan because cookies are not loaded.
+Auto-scanning...
+Skipping scan because cookies are not loaded.
+Auto-scanning...
+Skipping scan because cookies are not loaded.
+Auto-scanning...
+Skipping scan because cookies are not loaded.
+Auto-scanning...
+Skipping scan because cookies are not loaded.
+Auto-scanning...
+Skipping scan because cookies are not loaded.
+ * Restarting with stat
+ * Debugger is active!
+ * Debugger PIN: 631-326-424

--- a/app_output.log
+++ b/app_output.log
@@ -15,3 +15,37 @@ Skipping scan because cookies are not loaded.
 127.0.0.1 - - [13/Mar/2026 07:39:51] "GET /sectoral HTTP/1.1" 200 -
 127.0.0.1 - - [13/Mar/2026 07:39:52] "GET / HTTP/1.1" 200 -
 127.0.0.1 - - [13/Mar/2026 07:39:52] "GET /get_latest_data?rvol=0 HTTP/1.1" 200 -
+ * Detected change in '/app/app.py', reloading
+Warning: Could not load TradingView cookies. Scanning will be disabled. Error: can't find cookies file
+
+Location:
+    rookie-rs/src/common/paths.rs:48:7
+Auto-scanning...
+Skipping scan because cookies are not loaded.
+Auto-scanning...
+Skipping scan because cookies are not loaded.
+ * Restarting with stat
+ * Debugger is active!
+ * Debugger PIN: 631-326-424
+ * Detected change in '/app/app.py', reloading
+Warning: Could not load TradingView cookies. Scanning will be disabled. Error: can't find cookies file
+
+Location:
+    rookie-rs/src/common/paths.rs:48:7
+Auto-scanning...
+Skipping scan because cookies are not loaded.
+ * Restarting with stat
+ * Debugger is active!
+ * Debugger PIN: 631-326-424
+ * Detected change in '/app/app.py', reloading
+Warning: Could not load TradingView cookies. Scanning will be disabled. Error: can't find cookies file
+
+Location:
+    rookie-rs/src/common/paths.rs:48:7
+Auto-scanning...
+Skipping scan because cookies are not loaded.
+Auto-scanning...
+Skipping scan because cookies are not loaded.
+ * Restarting with stat
+ * Debugger is active!
+ * Debugger PIN: 631-326-424


### PR DESCRIPTION
- Implemented new Sectoral Heatmap screen for NSE stocks.
- Updated scanner to fetch and aggregate sectoral performance data.
- Added database migrations for sector/industry/change metadata.
- Implemented comprehensive NaN handling across all API responses.
- Resolved Pandas4Warning by updating select_dtypes usage.
- Enhanced UI with tooltips and sector-aligned squeeze indicators.